### PR TITLE
Small improvements iterator

### DIFF
--- a/src/loaders/normalize_scaler_loader.py
+++ b/src/loaders/normalize_scaler_loader.py
@@ -1,3 +1,4 @@
+import glob
 import os
 
 from nso_ds_classes.nso_ds_normalize_scaler import scaler_class_all
@@ -15,18 +16,6 @@ class NormalizeScalerLoader:
 
     def load(self) -> scaler_class_all:
         tif_file_name = os.path.basename(self.tif_filepath)
-        file_bands = [
-            os.path.join(
-                self.path_to_scaler_files, tif_file_name + f"_band{band_id}.save"
-            )
-            for band_id in range(1, 7)
-        ]
+        band_filepaths = glob.glob(f"{self.path_to_scaler_files}/{tif_file_name}*")
 
-        return scaler_class_all(
-            scaler_file_band1=file_bands[0],
-            scaler_file_band2=file_bands[1],
-            scaler_file_band3=file_bands[2],
-            scaler_file_band4=file_bands[3],
-            scaler_file_band5=file_bands[4],
-            scaler_file_band6=file_bands[5],
-        )
+        return scaler_class_all(scaler_band_filepaths=band_filepaths)

--- a/src/tif_model_iterator/tif_kernel_iterator.py
+++ b/src/tif_model_iterator/tif_kernel_iterator.py
@@ -343,15 +343,20 @@ class TifKernelIteratorGenerator:
             os.remove(os.path.join(self.output_file_name_generator.output_path, file))
 
 
-def func_cor_square(input_x_y):
+def func_cor_square(input_x_y, size: float = 2.0):
     """
     This function is used to make squares out of pixels for a inter connected output.
 
     @param input_x_y a pixel input variable to be made into a square.
+    @param size: float that indicates the lenghts of the sides of the square. Note that this should be consistent with the distance between points for the squares to have no overlap.
     @return the the squared pixel.
     """
-    rect = [round(input_x_y[0] / 2) * 2, round(input_x_y[1] / 2) * 2, 0, 0]
-    rect[2], rect[3] = rect[0] + 2, rect[1] + 2
+    rect = [
+        input_x_y[0] - size / 2.0,
+        input_x_y[1] - size / 2.0,
+        input_x_y[0] + size / 2.0,
+        input_x_y[1] + size / 2.0,
+    ]
     coords = Polygon(
         [
             (rect[0], rect[1]),

--- a/src/tif_model_iterator/tif_kernel_iterator.py
+++ b/src/tif_model_iterator/tif_kernel_iterator.py
@@ -131,6 +131,10 @@ class TifKernelIteratorGenerator:
 
         subset_df = self._filter_out_empty_pixels(subset_df)
 
+        if len(subset_df) == 0:
+            print("This part is empty, so we skip the next steps.")
+            return
+
         # Check if a normalizer or a  scaler has to be used.
         if self.normalize_scaler is not False:
             print("Normalizing/Scaling data")
@@ -337,10 +341,6 @@ class TifKernelIteratorGenerator:
             self.output_file_name_generator.glob_wild_card_for_all_part_files()
         ):
             os.remove(os.path.join(self.output_file_name_generator.output_path, file))
-
-
-
-
 
 
 def func_cor_square(input_x_y):


### PR DESCRIPTION
- Appropriately deal with parts of the tif file that do not contain any pixels (this can happen as it is always in a rectangular shape)
- Make the bands used by the iterator variable instead of fixed at 6
- Make square polygons of variable size around the points instead of using the point as 1 corner.